### PR TITLE
fix compilation on galactic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Ros2 Controls driver for controlling Lynxmotion smart servos.
 
+Add to your ROS2 workspace and compile
+
+```
+reset && colcon build --symlink-install
+```
+
 # See Also
 - [Lynxmotion/LSS-ROS2-Hexapod](https://github.com/Lynxmotion/LSS-ROS2-Hexapod) Hexapod Project
 - [Lynxmotion/LSS-ROS2-Humanoid](https://github.com/Lynxmotion/LSS-ROS2-Humanoid) Humanoid Project

--- a/include/ros2_lss_bus/ros2_lss_bus.hpp
+++ b/include/ros2_lss_bus/ros2_lss_bus.hpp
@@ -109,11 +109,21 @@ using LssBusHardwareBaseInterface = hardware_interface::SystemInterface;
         previous_state) override;
 #endif
 
+#if defined(ROS_FOXY) || defined(ROS_GALACTIC)
+        LSS_HARDWARE_PUBLIC
+        hardware_interface::return_type read() override;
+
+        LSS_HARDWARE_PUBLIC
+        hardware_interface::return_type write() override;
+#else
+	// the additional time and duration parameters were introduced in iron
+	// https://github.com/ros-controls/ros2_control/blob/iron/hardware_interface/include/hardware_interface/system_interface.hpp
         LSS_HARDWARE_PUBLIC
         hardware_interface::return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
         LSS_HARDWARE_PUBLIC
         hardware_interface::return_type write(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+#endif
 
     protected:
         class StateData {

--- a/src/ros2_lss_bus.cpp
+++ b/src/ros2_lss_bus.cpp
@@ -473,7 +473,11 @@ LssBusHardware::return_type LssBusHardware::on_deactivate(
 #endif
     }
 
+#if defined(ROS_FOXY) || defined(ROS_GALACTIC)
+    hardware_interface::return_type LssBusHardware::read()
+#else
     hardware_interface::return_type LssBusHardware::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+#endif
     {
       int n;
         if(reply_pending) {
@@ -518,7 +522,11 @@ LssBusHardware::return_type LssBusHardware::on_deactivate(
         return hardware_interface::return_type::OK;
     }
 
+#if defined(ROS_FOXY) || defined(ROS_GALACTIC)
+    hardware_interface::return_type LssBusHardware::write()
+#else
     hardware_interface::return_type LssBusHardware::write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+#endif
     {
       // convert positions from Ros to Lss
       for(size_t i=0; i < command_position_.size(); i++) {


### PR DESCRIPTION
This was probably last tested on humble. However on galactic it doesn't compile (mentioned as the required platform in the LSS-ROS2-Arms repo). This is just because the `read` and `write` functions of the system hardware interface have a breaking change starting with ROS iron.

I added some `#if defined` statements for this. I decided against including older platforms than FOXY to catch this, because the lines would have become long, and I dare say that older platforms aren't supported anyway.

With this fix, it compiles and works.